### PR TITLE
pip install not installing all requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To get started clone this repo and your main file will have a basic starter Proj
 You will need to have raylib installed!
 
 ```bash
-pip install raylib
+pip3 install -r "requirements.txt"
 ```
 
 ### Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyray
+raylib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyray
 raylib
+simpleJDB


### PR DESCRIPTION
It seems `simpleJDB` was not identified in https://github.com/Milkman337/EightBallEngine#prerequisites, so the user will have to deal with `ModuleNotFoundError: No module named 'simpleJDB'` error. 

I made one new file called **requirements.txt** which has all the dependencies needed. I also updated the **README.md** `#prerequisites` section to install all dependencies directly from `requirements.txt`.
